### PR TITLE
Add functions to control RT upgrades from outside

### DIFF
--- a/src/d3d9/d3d9.def
+++ b/src/d3d9/d3d9.def
@@ -25,3 +25,6 @@ EXPORTS
   DXVK_UnRegisterAnnotation @28258 NONAME
 
   Direct3D9ForceHybridEnumeration @16 NONAME PRIVATE
+
+  DXVK_HDR_DisableFormatUpgrade @28259
+  DXVK_HDR_EnableFormatUpgrade @28260

--- a/src/d3d9/d3d9.def
+++ b/src/d3d9/d3d9.def
@@ -26,5 +26,5 @@ EXPORTS
 
   Direct3D9ForceHybridEnumeration @16 NONAME PRIVATE
 
-  DXVK_HDR_DisableFormatUpgrade @28259
-  DXVK_HDR_EnableFormatUpgrade @28260
+  DXVK_D3D9_HDR_DisableRenderTargetUpgrade @28259
+  DXVK_D3D9_HDR_EnableRenderTargetUpgrade @28260

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -10,6 +10,8 @@
 
 namespace dxvk {
 
+  bool D3D9CommonTexture::forceDisableUpgrade = false;
+
   void D3D9CommonTexture::RtUpgradeLogger(
           D3D9Format originalFormat,
           D3D9Format upgradedFormat)
@@ -55,7 +57,7 @@ namespace dxvk {
         throw DxvkError("D3D9: Incompatible pool type for texture sharing.");
       }
     }
-    if (m_device->GetOptions()->enableRenderTargetUpgrade && (m_desc.Usage & D3DUSAGE_RENDERTARGET))
+    if (m_device->GetOptions()->enableRenderTargetUpgrade && (m_desc.Usage & D3DUSAGE_RENDERTARGET) && !forceDisableUpgrade)
     {
       D3D9Format ugRT_RGBA8_to   = D3D9Format(m_device->GetOptions()->upgrade_RGBA8_renderTargetTo);
       D3D9Format ugRT_RGBX8_to   = D3D9Format(m_device->GetOptions()->upgrade_RGBX8_renderTargetTo);

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -10,7 +10,7 @@
 
 namespace dxvk {
 
-  bool D3D9CommonTexture::forceDisableUpgrade = false;
+  bool D3D9CommonTexture::forceDisableRenderTargetUpgrade = false;
 
   void D3D9CommonTexture::RtUpgradeLogger(
           D3D9Format originalFormat,
@@ -57,7 +57,7 @@ namespace dxvk {
         throw DxvkError("D3D9: Incompatible pool type for texture sharing.");
       }
     }
-    if (m_device->GetOptions()->enableRenderTargetUpgrade && (m_desc.Usage & D3DUSAGE_RENDERTARGET) && !forceDisableUpgrade)
+    if (m_device->GetOptions()->enableRenderTargetUpgrade && (m_desc.Usage & D3DUSAGE_RENDERTARGET) && !forceDisableRenderTargetUpgrade)
     {
       D3D9Format ugRT_RGBA8_to   = D3D9Format(m_device->GetOptions()->upgrade_RGBA8_renderTargetTo);
       D3D9Format ugRT_RGBX8_to   = D3D9Format(m_device->GetOptions()->upgrade_RGBX8_renderTargetTo);

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -484,6 +484,8 @@ namespace dxvk {
 
     ID3D9VkInteropTexture* GetVkInterop() { return &m_d3d9Interop; }
 
+    static bool forceDisableUpgrade;
+
   private:
 
     void RtUpgradeLogger(

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -484,7 +484,7 @@ namespace dxvk {
 
     ID3D9VkInteropTexture* GetVkInterop() { return &m_d3d9Interop; }
 
-    static bool forceDisableUpgrade;
+    static bool forceDisableRenderTargetUpgrade;
 
   private:
 

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -101,4 +101,14 @@ extern "C" {
   DLLEXPORT void __stdcall Direct3D9ForceHybridEnumeration(UINT uHybrid) {
   }
 
+  DLLEXPORT bool __stdcall DXVK_HDR_DisableFormatUpgrade() {
+      dxvk::D3D9CommonTexture::forceDisableUpgrade = true;
+      return true;
+  }
+
+  DLLEXPORT bool __stdcall DXVK_HDR_EnableFormatUpgrade() {
+      dxvk::D3D9CommonTexture::forceDisableUpgrade = false;
+      return true;
+  }
+
 }

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -101,13 +101,13 @@ extern "C" {
   DLLEXPORT void __stdcall Direct3D9ForceHybridEnumeration(UINT uHybrid) {
   }
 
-  DLLEXPORT bool __stdcall DXVK_HDR_DisableFormatUpgrade() {
-      dxvk::D3D9CommonTexture::forceDisableUpgrade = true;
+  DLLEXPORT bool __stdcall DXVK_D3D9_HDR_DisableRenderTargetUpgrade() {
+      dxvk::D3D9CommonTexture::forceDisableRenderTargetUpgrade = true;
       return true;
   }
 
-  DLLEXPORT bool __stdcall DXVK_HDR_EnableFormatUpgrade() {
-      dxvk::D3D9CommonTexture::forceDisableUpgrade = false;
+  DLLEXPORT bool __stdcall DXVK_D3D9_HDR_EnableRenderTargetUpgrade() {
+      dxvk::D3D9CommonTexture::forceDisableRenderTargetUpgrade = false;
       return true;
   }
 


### PR DESCRIPTION
Creates and exports 2 functions - DXVK_HDR_DisableFormatUpgrade and DXVK_HDR_EnableFormatUpgrade, giving developers more control when creating render targets. 